### PR TITLE
Updated google-collections 1.0 dependency to guava r09.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   
   :dependencies [
                  [jvyaml "1.0.0"]
-                 [com.google.collections/google-collections "1.0"]
+                 [com.google.guava/guava "r09"]
                  ]
   :dev-dependencies [
                      [org.apache.hadoop/hadoop-core "0.20.2-dev"]


### PR DESCRIPTION
google-collections is deprecated, as discussed [here](http://code.google.com/p/google-collections/):

```
What you see here is ancient and unmaintained. Do not use it.
```

The new Guava is fully backwards-compatible, and won't clash with other projects using guava (like pallet's jclouds dependency.)
