### PR TITLE
JobConf Configuration should inherit from FileSystem's Configuration

### DIFF
--- a/src/jvm/backtype/hadoop/Consolidator.java
+++ b/src/jvm/backtype/hadoop/Consolidator.java
@@ -82,7 +82,7 @@ public class Consolidator {
 
     public static void consolidate(FileSystem fs, RecordStreamFactory streams, PathLister lister, List<String> dirs,
         long targetSizeBytes, String extension) throws IOException {
-        JobConf conf = new JobConf(Consolidator.class);
+        JobConf conf = new JobConf(fs.getConf(), Consolidator.class);
         String fsUri = fs.getUri().toString();
         ConsolidatorArgs args = new ConsolidatorArgs(fsUri, streams, lister, dirs, targetSizeBytes, extension);
         Utils.setObject(conf, ARGS, args);


### PR DESCRIPTION
I'm proposing that JobConf should inherit from the FileSystem's configuration for a Consolidation.
