### PR TITLE
Use slf4j instead of log4j to support other logging backends

### DIFF
--- a/dfs-datastores/src/main/java/com/backtype/hadoop/AbstractFileCopyMapper.java
+++ b/dfs-datastores/src/main/java/com/backtype/hadoop/AbstractFileCopyMapper.java
@@ -8,13 +8,14 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.*;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.UUID;
 
 public abstract class AbstractFileCopyMapper extends MapReduceBase implements Mapper<Text, Text, NullWritable, NullWritable> {
-    public static Logger LOG = Logger.getLogger(AbstractFileCopyMapper.class);
+    public static Logger LOG = LoggerFactory.getLogger(AbstractFileCopyMapper.class);
 
     private FileSystem fsSource;
     private FileSystem fsDest;

--- a/dfs-datastores/src/main/java/com/backtype/hadoop/Consolidator.java
+++ b/dfs-datastores/src/main/java/com/backtype/hadoop/Consolidator.java
@@ -11,7 +11,8 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.*;
 import org.apache.hadoop.mapred.*;
 import org.apache.hadoop.mapred.lib.NullOutputFormat;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -142,7 +143,7 @@ public class Consolidator {
     }
 
     public static class ConsolidatorMapper extends MapReduceBase implements Mapper<ArrayWritable, Text, NullWritable, NullWritable> {
-        public static Logger LOG = Logger.getLogger(ConsolidatorMapper.class);
+        public static Logger LOG = LoggerFactory.getLogger(ConsolidatorMapper.class);
 
         FileSystem fs;
         ConsolidatorArgs args;

--- a/dfs-datastores/src/main/java/com/backtype/hadoop/pail/Pail.java
+++ b/dfs-datastores/src/main/java/com/backtype/hadoop/pail/Pail.java
@@ -7,14 +7,15 @@ import com.backtype.support.Utils;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.*;
 
 public class Pail<T> extends AbstractPail implements Iterable<T>{
-    public static Logger LOG = Logger.getLogger(Pail.class);
+    public static Logger LOG = LoggerFactory.getLogger(Pail.class);
 
     public static final String META = "pail.meta";
 

--- a/dfs-datastores/src/main/java/com/backtype/hadoop/pail/PailOutputFormat.java
+++ b/dfs-datastores/src/main/java/com/backtype/hadoop/pail/PailOutputFormat.java
@@ -8,14 +8,15 @@ import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.*;
 import org.apache.hadoop.util.Progressable;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
 public class  PailOutputFormat extends FileOutputFormat<Text, BytesWritable> {
-    public static Logger LOG = Logger.getLogger(PailOutputFormat.class);
+    public static Logger LOG = LoggerFactory.getLogger(PailOutputFormat.class);
     public static final String SPEC_ARG = "pail_spec_arg";
 
     // we limit the size of outputted files because of s3 file limits

--- a/dfs-datastores/src/main/java/com/backtype/hadoop/pail/SequenceFileFormat.java
+++ b/dfs-datastores/src/main/java/com/backtype/hadoop/pail/SequenceFileFormat.java
@@ -18,7 +18,8 @@ import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.io.compress.DefaultCodec;
 import org.apache.hadoop.io.compress.GzipCodec;
 import org.apache.hadoop.mapred.*;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -82,7 +83,7 @@ public class SequenceFileFormat implements PailFormat {
 
 
     public static class SequenceFilePailRecordReader implements RecordReader<Text, BytesWritable> {
-        private static Logger LOG = Logger.getLogger(SequenceFilePailRecordReader.class);
+        private static Logger LOG = LoggerFactory.getLogger(SequenceFilePailRecordReader.class);
         public static final int NUM_TRIES = 10;
 
         JobConf conf;

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -11,7 +11,9 @@ object BijectionBuild extends Build {
     crossPaths := false,
 
     libraryDependencies ++= Seq(
-      "com.novocode" % "junit-interface" % "0.10-M2" % "test"
+      "com.novocode" % "junit-interface" % "0.10-M2" % "test",
+      // To silence warning in test logs. Library should depend only on the API.
+      "org.slf4j" % "slf4j-log4j12" % "1.6.6" % "test"
     ),
 
     resolvers ++= Seq(
@@ -87,8 +89,7 @@ object BijectionBuild extends Build {
   ).settings(
     name := "dfs-datastores",
     libraryDependencies ++= Seq(
-      "log4j" % "log4j" % "1.2.16",
-      "org.slf4j" % "slf4j-log4j12" % "1.6.6",
+      "org.slf4j" % "slf4j-api" % "1.6.6",
       "jvyaml" % "jvyaml" % "1.0.0",
       "com.google.guava" % "guava" % "13.0",
       "org.apache.hadoop" % "hadoop-core" % "1.0.3"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -11,9 +11,7 @@ object BijectionBuild extends Build {
     crossPaths := false,
 
     libraryDependencies ++= Seq(
-      "com.novocode" % "junit-interface" % "0.10-M2" % "test",
-      "org.scalacheck" %% "scalacheck" % "1.10.0" % "test" withSources(),
-      "org.scala-tools.testing" %% "specs" % "1.6.9" % "test" withSources()
+      "com.novocode" % "junit-interface" % "0.10-M2" % "test"
     ),
 
     resolvers ++= Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.12.0


### PR DESCRIPTION
Logback users are getting a [multiple bindings warning]((http://www.slf4j.org/codes.html#multiple_bindings).  This removes the hard dependency on log4j:

> Embedded components such as libraries or frameworks should not declare a dependency on any SLF4J binding but only depend on slf4j-api. When a library declares a compile-time dependency on a SLF4J binding, it imposes that binding on the end-user

Keeps log4j as the internal logging implementation for datastores' tests.
