### PR TITLE
keep around a configurable number of versions, default 3

### DIFF
--- a/dfs-datastores-cascading/src/main/java/com/backtype/cascading/tap/VersionedTap.java
+++ b/dfs-datastores-cascading/src/main/java/com/backtype/cascading/tap/VersionedTap.java
@@ -21,6 +21,9 @@ public class VersionedTap extends Hfs {
 
   public Long version = null;
 
+  // a sane default for the number of versions of your data to keep around
+  private int versionsToKeep = 3;
+
   // source-specific
   public TapMode mode;
 
@@ -33,9 +36,23 @@ public class VersionedTap extends Hfs {
     this.mode = mode;
   }
 
+
   public VersionedTap setVersion(long version) {
     this.version = version;
     return this;
+  }
+
+  /**
+    * Sets the number of versions of your data to keep. Unneeded versions are cleaned up on creation
+    * of a new one. Pass a negative number to keep all versions.
+    */
+  public VersionTap setVersionsToKeep(int versionsToKeep) {
+    this.versionsToKeep = versionsToKeep;
+    return this;
+  }
+
+  public int getVersionsToKeep() {
+    return this.versionstoKeep;
   }
 
   public String getOutputDirectory() {
@@ -113,6 +130,7 @@ public class VersionedTap extends Hfs {
       store.succeedVersion(newVersionPath);
       CascadingUtils.markSuccessfulOutputDir(new Path(newVersionPath), conf);
       newVersionPath = null;
+      store.cleanup(getVersionsToKeep());
     }
 
     return true;

--- a/dfs-datastores-cascading/src/main/java/com/backtype/cascading/tap/VersionedTap.java
+++ b/dfs-datastores-cascading/src/main/java/com/backtype/cascading/tap/VersionedTap.java
@@ -46,13 +46,13 @@ public class VersionedTap extends Hfs {
     * Sets the number of versions of your data to keep. Unneeded versions are cleaned up on creation
     * of a new one. Pass a negative number to keep all versions.
     */
-  public VersionTap setVersionsToKeep(int versionsToKeep) {
+  public VersionedTap setVersionsToKeep(int versionsToKeep) {
     this.versionsToKeep = versionsToKeep;
     return this;
   }
 
   public int getVersionsToKeep() {
-    return this.versionstoKeep;
+    return this.versionsToKeep;
   }
 
   public String getOutputDirectory() {

--- a/dfs-datastores/src/main/java/com/backtype/hadoop/datastores/VersionedStore.java
+++ b/dfs-datastores/src/main/java/com/backtype/hadoop/datastores/VersionedStore.java
@@ -187,7 +187,7 @@ public class VersionedStore {
 
     /** The path to the hadoop-created success flag file which may or may not exist */
     private String successFlagPath(long version) {
-        return new Path(versionPath(version), HADOOP_SUCCESS_FLAG).toString()
+        return new Path(versionPath(version), HADOOP_SUCCESS_FLAG).toString();
     }
 
     private Path normalizePath(String p) {

--- a/dfs-datastores/src/main/java/com/backtype/hadoop/datastores/VersionedStore.java
+++ b/dfs-datastores/src/main/java/com/backtype/hadoop/datastores/VersionedStore.java
@@ -108,8 +108,10 @@ public class VersionedStore {
     }
 
     public void deleteVersion(long version) throws IOException {
-        fs.delete(new Path(versionPath(version)), true);
+        // Be sure to delete success indicators before data
         fs.delete(new Path(tokenPath(version)), false);
+        fs.delete(new Path(successFlagPath(version)), false);
+        fs.delete(new Path(versionPath(version)), true);
     }
 
     public void succeedVersion(String path) throws IOException {
@@ -121,20 +123,22 @@ public class VersionedStore {
     }
 
     public void cleanup() throws IOException {
+        // Default behavior is to clean up NOTHING
         cleanup(-1);
     }
 
     public void cleanup(int versionsToKeep) throws IOException {
-        List<Long> versions = getAllVersions();
+        final List<Long> versions = getAllVersions();
+        final HashSet<Long> keepers;
         if(versionsToKeep >= 0) {
-            versions = versions.subList(0, Math.min(versions.size(), versionsToKeep));
+            keepers = new HashSet<Long>(versions.subList(0, Math.min(versions.size(), versionsToKeep)));
+        } else {
+            keepers = new HashSet<Long>(versions);
         }
-        HashSet<Long> keepers = new HashSet<Long>(versions);
 
-        for(Path p: listDir(root)) {
-            Long v = parseVersion(p.toString());
+        for(Long v : versions) {
             if(v!=null && !keepers.contains(v)) {
-                fs.delete(p, true);
+                    deleteVersion(v);
             }
         }
     }
@@ -179,6 +183,11 @@ public class VersionedStore {
 
     private String tokenPath(long version) {
         return new Path(root, "" + version + FINISHED_VERSION_SUFFIX).toString();
+    }
+
+    /** The path to the hadoop-created success flag file which may or may not exist */
+    private String successFlagPath(long version) {
+        return new Path(versionPath(version), HADOOP_SUCCESS_FLAG).toString()
     }
 
     private Path normalizePath(String p) {

--- a/dfs-datastores/src/test/java/com/backtype/hadoop/datastores/VersionedStoreTest.java
+++ b/dfs-datastores/src/test/java/com/backtype/hadoop/datastores/VersionedStoreTest.java
@@ -1,0 +1,35 @@
+package com.backtype.hadoop.datastores;
+
+import com.backtype.support.FSTestCase;
+import junit.framework.Assert;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+
+
+import static com.backtype.support.TestUtils.getTmpPath;
+
+public class VersionedStoreTest extends FSTestCase {
+
+    public void testCleanup() throws Exception{
+        String tmp1 = getTmpPath(fs, "versions");
+        VersionedStore vs = new VersionedStore(tmp1);
+        for (int i = 1; i <= 4; i ++) {
+            String version = vs.createVersion(i);
+            fs.mkdirs(new Path(version));
+            vs.succeedVersion(i);
+        }
+        FileStatus[] files = fs.listStatus(new Path(tmp1));
+        Assert.assertEquals(files.length, 8);
+        vs.cleanup(2);
+        files = fs.listStatus(new Path(tmp1));
+        Assert.assertEquals(files.length, 4);
+        for (FileStatus f : files) {
+            String path = f.getPath().toString();
+            Assert.assertTrue(path.endsWith("3") ||
+            path.endsWith("4") ||
+            path.endsWith("3.version") ||
+            path.endsWith(("4.version")));
+        }
+    }
+
+}


### PR DESCRIPTION
Patch to cleanup old versions of a dataset so we don't litter HDFS with old data. 
