### PR TITLE
Allow custom file formats (aside from SequenceFileFormat) to pass args

### DIFF
--- a/dfs-datastores/src/main/java/com/backtype/hadoop/pail/PailFormat.java
+++ b/dfs-datastores/src/main/java/com/backtype/hadoop/pail/PailFormat.java
@@ -3,6 +3,9 @@ package com.backtype.hadoop.pail;
 import com.backtype.hadoop.formats.RecordStreamFactory;
 import org.apache.hadoop.mapred.InputFormat;
 
+import java.util.Map;
+
 public interface PailFormat extends RecordStreamFactory {
+    public void configure(Map<String, Object> args);
     public Class<? extends InputFormat> getInputFormatClass();
 }

--- a/dfs-datastores/src/main/java/com/backtype/hadoop/pail/PailFormatFactory.java
+++ b/dfs-datastores/src/main/java/com/backtype/hadoop/pail/PailFormatFactory.java
@@ -29,15 +29,17 @@ public class PailFormatFactory {
     }
 
     public static PailFormat create(PailSpec spec) {
+        PailFormat format = null;
         if(spec==null || spec.getName()==null) spec = getDefaultCopy();
-        String format = spec.getName();
+        String formatName = spec.getName();
         Map<String, Object> args = spec.getArgs();
         if(args==null) args = new HashMap<String, Object>();
-        if(format.equals(SEQUENCE_FILE)) {
-            return new SequenceFileFormat(args);
-        } else {
+        if(formatName.equals(SEQUENCE_FILE)) {
+             format = new SequenceFileFormat();
+        }
+        else {
             try {
-                return (PailFormat) Class.forName(format).newInstance();
+                format = (PailFormat) Class.forName(formatName).newInstance();
             } catch(ClassNotFoundException e) {
                 throw new RuntimeException(e);
             } catch(InstantiationException e) {
@@ -46,5 +48,7 @@ public class PailFormatFactory {
                 throw new RuntimeException(e);
             }
         }
+        format.configure(args);
+        return format;
     }
 }

--- a/dfs-datastores/src/main/java/com/backtype/hadoop/pail/SequenceFileFormat.java
+++ b/dfs-datastores/src/main/java/com/backtype/hadoop/pail/SequenceFileFormat.java
@@ -54,7 +54,7 @@ public class SequenceFileFormat implements PailFormat {
     private String _typeArg;
     private String _codecArg;
 
-    public SequenceFileFormat(Map<String, Object> args) {
+    public void configure(Map<String, Object> args) {
         args = new KeywordArgParser()
                 .add(TYPE_ARG, null, true, TYPE_ARG_RECORD, TYPE_ARG_BLOCK)
                 .add(CODEC_ARG, CODEC_ARG_DEFAULT, false, CODEC_ARG_DEFAULT, CODEC_ARG_GZIP, CODEC_ARG_BZIP2)


### PR DESCRIPTION
I'm working on an AvroFileFormat, and I'd like to be able to pass it args -- this seemed like the least bad way to make it happen. Open to suggestions for other approaches.
