### PR TITLE
Modify version checker to disregard paths starting with underscores and dangling versions.

### DIFF
--- a/dfs-datastores/src/main/java/com/backtype/hadoop/datastores/VersionedStore.java
+++ b/dfs-datastores/src/main/java/com/backtype/hadoop/datastores/VersionedStore.java
@@ -16,7 +16,7 @@ import java.util.HashSet;
 import java.util.List;
 
 public class VersionedStore {
-    private static final String FINISHED_VERSION_SUFFIX = ".version";
+    public static final String FINISHED_VERSION_SUFFIX = ".version";
     public static final String HADOOP_SUCCESS_FLAG = "_SUCCESS";
 
     private String root;
@@ -164,11 +164,16 @@ public class VersionedStore {
                     }
                 } else {
                     if (!p.getName().startsWith("_")) {
-                        if (p.getName().endsWith(FINISHED_VERSION_SUFFIX)) {
-                            ret.add(validateAndGetVersion(p.toString()));
-                        } else if (status != null && status.isDir() && getFileSystem().exists(new Path(p, HADOOP_SUCCESS_FLAG))) {
-                            // FORCE the _SUCCESS flag into the versioned store directory.
-                            ret.add(validateAndGetVersion(p.toString() + FINISHED_VERSION_SUFFIX));
+                        try {
+                            if (p.getName().endsWith(FINISHED_VERSION_SUFFIX)) {
+                                ret.add(validateAndGetVersion(p.toString()));
+                            } else if (status != null && status.isDir() && getFileSystem().exists(new Path(p, HADOOP_SUCCESS_FLAG))) {
+                                // FORCE the _SUCCESS flag into the versioned store directory.
+                                ret.add(validateAndGetVersion(p.toString() + FINISHED_VERSION_SUFFIX));
+                            }
+                        } catch (RuntimeException e) {
+                            // Skip this version
+                            continue;
                         }
                     }
                 }

--- a/dfs-datastores/src/test/java/com/backtype/hadoop/datastores/VersionedStoreTest.java
+++ b/dfs-datastores/src/test/java/com/backtype/hadoop/datastores/VersionedStoreTest.java
@@ -5,6 +5,10 @@ import junit.framework.Assert;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 
+import java.io.File;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import static com.backtype.support.TestUtils.getTmpPath;
 
@@ -30,6 +34,30 @@ public class VersionedStoreTest extends FSTestCase {
             path.endsWith("3.version") ||
             path.endsWith(("4.version")));
         }
+    }
+
+    public void testMultipleVersions() throws Exception{
+        String tmp1 = getTmpPath(fs, "versions_checker");
+        VersionedStore vs = new VersionedStore(tmp1);
+        for (int i = 1; i <= 4; i ++) {
+            String version = vs.createVersion(i);
+            fs.mkdirs(new Path(version));
+            vs.succeedVersion(i);
+        }
+        new File(new Path(tmp1, "5" + VersionedStore.FINISHED_VERSION_SUFFIX).toString()).createNewFile();
+        Path invalidPath = new Path(tmp1, "_test");
+        fs.mkdirs(invalidPath);
+        new File(new Path(invalidPath, VersionedStore.HADOOP_SUCCESS_FLAG).toString()).createNewFile();
+
+        List<Long> allVersions = vs.getAllVersions();
+        Set<Long> output = new HashSet<Long>();
+        output.addAll(allVersions);
+        Set<Long> expected = new HashSet<Long>();
+        for (int i = 1; i <= 4; i ++) {
+            expected.add(Long.valueOf(i));
+        }
+
+        Assert.assertEquals(output, expected);
     }
 
 }

--- a/dfs-datastores/src/test/java/com/backtype/hadoop/pail/PailOpsTest.java
+++ b/dfs-datastores/src/test/java/com/backtype/hadoop/pail/PailOpsTest.java
@@ -13,7 +13,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.apache.hadoop.fs.Path;
-import org.junit.Ignore;
 import static com.backtype.support.TestUtils.*;
 
 public class PailOpsTest extends FSTestCase {
@@ -394,7 +393,6 @@ public class PailOpsTest extends FSTestCase {
         //TODO: test that original pail is now empty
     }
 
-    @Ignore
     public void testAbsorb() throws Exception {
         appendOperationTest(new AppendOperation() {
             public void append(Pail into, Pail data, int renameMode) throws IOException {

--- a/dfs-datastores/src/test/java/com/backtype/hadoop/pail/PailOpsTest.java
+++ b/dfs-datastores/src/test/java/com/backtype/hadoop/pail/PailOpsTest.java
@@ -13,6 +13,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.apache.hadoop.fs.Path;
+import org.junit.Ignore;
 import static com.backtype.support.TestUtils.*;
 
 public class PailOpsTest extends FSTestCase {
@@ -393,6 +394,7 @@ public class PailOpsTest extends FSTestCase {
         //TODO: test that original pail is now empty
     }
 
+    @Ignore
     public void testAbsorb() throws Exception {
         appendOperationTest(new AppendOperation() {
             public void append(Pail into, Pail data, int renameMode) throws IOException {


### PR DESCRIPTION
I added a test which passes, though a number of tests in this repo are flaky.
