### PR TITLE
checkValidStructure fails when using yarn

### DIFF
--- a/dfs-datastores/src/main/java/com/backtype/hadoop/pail/Pail.java
+++ b/dfs-datastores/src/main/java/com/backtype/hadoop/pail/Pail.java
@@ -589,7 +589,6 @@ public class Pail<T> extends AbstractPail implements Iterable<T>{
 
     protected List<String> componentsFromRoot(String relpath) {
        String fullpath = toFullPath(relpath);
-       LOG.info("Full path:" + fullpath);
        List<String> full = Utils.componentize(fullpath);
        List<String> root = Utils.componentize(getRoot());
        return Utils.stripRoot(root, full);

--- a/dfs-datastores/src/main/java/com/backtype/hadoop/pail/Pail.java
+++ b/dfs-datastores/src/main/java/com/backtype/hadoop/pail/Pail.java
@@ -589,6 +589,7 @@ public class Pail<T> extends AbstractPail implements Iterable<T>{
 
     protected List<String> componentsFromRoot(String relpath) {
        String fullpath = toFullPath(relpath);
+       LOG.info("Full path:" + fullpath);
        List<String> full = Utils.componentize(fullpath);
        List<String> root = Utils.componentize(getRoot());
        return Utils.stripRoot(root, full);
@@ -596,11 +597,10 @@ public class Pail<T> extends AbstractPail implements Iterable<T>{
 
     protected void checkValidStructure(String userfilename) {
         List<String> full = componentsFromRoot(userfilename);
-        full.remove(full.size()-1);
-        //hack to get around how hadoop does outputs --> _temporary and _attempt*
-        while(full.size()>0 && full.get(0).startsWith("_")) {
-            full.remove(0);
-        }
+
+        full.remove(full.size() - 1);
+        full = Utils.cleanHadoopPath(full);
+
         if(!getSpec().getStructure().isValidTarget(full.toArray(new String[full.size()]))) {
             throw new IllegalArgumentException(
                     userfilename + " is not valid with the pail structure " + getSpec().toString() +

--- a/dfs-datastores/src/main/java/com/backtype/support/Utils.java
+++ b/dfs-datastores/src/main/java/com/backtype/support/Utils.java
@@ -167,6 +167,32 @@ public class Utils {
         }
     }
 
+
+
+    public static List<String> cleanHadoopPath(List<String> components) {
+        //hack to get around how hadoop does outputs --> _temporary and _attempt*
+        //We go bottom up and stop there if there's a _attempt* or attempt* directory on the way
+        int first = components.size() - 1;
+        if (first <= 0)
+            return components;
+        Boolean isHadoopComponent = false;
+        while(first > 0)
+        {
+            String name = components.get(first);
+            if (name.startsWith("_attempt_") || name.startsWith("attempt_")) {
+                isHadoopComponent = true;
+                break;
+            }
+            first--;
+        }
+        if (! isHadoopComponent)
+            return components;
+
+        return  components.subList(first + 1, components.size());
+    }
+
+
+
     public static boolean firstNBytesSame(FileSystem fs1, Path p1, FileSystem fs2, Path p2, long n) throws IOException {
         FSDataInputStream f1 = fs1.open(p1);
         FSDataInputStream f2 = fs2.open(p2);

--- a/dfs-datastores/src/test/java/com/backtype/support/UtilsTest.java
+++ b/dfs-datastores/src/test/java/com/backtype/support/UtilsTest.java
@@ -3,6 +3,7 @@ package com.backtype.support;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import junit.framework.TestCase;
 import org.apache.hadoop.conf.Configuration;
@@ -11,6 +12,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.BytesWritable;
 import static com.backtype.support.TestUtils.*;
+import junit.framework.*;
 
 public class UtilsTest extends TestCase {
     public void testGetBytes() {
@@ -92,6 +94,25 @@ public class UtilsTest extends TestCase {
         assertTrue(Utils.firstNBytesSame(fs, new Path(path1), fs, new Path(path2), 5));
         assertTrue(Utils.firstNBytesSame(fs, new Path(path1), fs, new Path(path2), 1000));
 
+
+    }
+
+    public void testHadoopPathCleanup(){
+
+        String expected = "A/B/C";
+
+
+
+        String[] mrv1 = ("/root/somedir/_temporary/_attempt_xxxxx_yyyyyy/" + expected ).split("/");
+
+        String[] yarn =("/root/somedir/_temporary/1/_temporary/attempt_xxxxx_yyyyyy/" + expected).split("/");
+
+
+        String[] noHadoop = "/root/somedir/someotherdir/A/B/C".split("/");
+
+        Assert.assertEquals(Arrays.asList(expected.split("/")), Utils.cleanHadoopPath(Arrays.asList(mrv1)));
+        Assert.assertEquals(Arrays.asList(expected.split("/")), Utils.cleanHadoopPath(Arrays.asList(yarn)));
+        Assert.assertEquals(Arrays.asList(noHadoop), Utils.cleanHadoopPath(Arrays.asList(noHadoop)));
 
     }
 }

--- a/dfs-datastores/src/test/java/com/backtype/support/UtilsTest.java
+++ b/dfs-datastores/src/test/java/com/backtype/support/UtilsTest.java
@@ -98,21 +98,14 @@ public class UtilsTest extends TestCase {
     }
 
     public void testHadoopPathCleanup(){
-
         String expected = "A/B/C";
 
-
-
         String[] mrv1 = ("/root/somedir/_temporary/_attempt_xxxxx_yyyyyy/" + expected ).split("/");
-
         String[] yarn =("/root/somedir/_temporary/1/_temporary/attempt_xxxxx_yyyyyy/" + expected).split("/");
-
-
         String[] noHadoop = "/root/somedir/someotherdir/A/B/C".split("/");
 
         Assert.assertEquals(Arrays.asList(expected.split("/")), Utils.cleanHadoopPath(Arrays.asList(mrv1)));
         Assert.assertEquals(Arrays.asList(expected.split("/")), Utils.cleanHadoopPath(Arrays.asList(yarn)));
         Assert.assertEquals(Arrays.asList(noHadoop), Utils.cleanHadoopPath(Arrays.asList(noHadoop)));
-
     }
 }


### PR DESCRIPTION
The temporary directory hierarchy has changed between mr v1 and YARN. We run the same jobs on both frameworks and map outputs are typically laid out the following way:

Hadoop MR v1:
hdfs://root/tmp/foo/_temporary/_attempt_201405190855_34040_m_000005_0/2014-05-19/13/EU/part-000050

Hadoop YARN:
hdfs://root/tmp/foo/_temporary/1/_temporary/attempt_1398254330120_19508_m_000000_0/2014-05-19/13/EU/part-000000

The code assumed pruning hadoop specific directories was a matter of dropping every directory starting with _, from the beginning onwards, and stopping at the first non _ prefixed dir. It's no longer true when using yarn (along with cascading in our test case). With YARN the check fails systematically.
