### PR TITLE
'lein uberjar' doesn't include compiled classes for dfs-datastore

### DIFF
--- a/dfs-datastores/project.clj
+++ b/dfs-datastores/project.clj
@@ -34,9 +34,4 @@
              {:dependencies [[org.slf4j/slf4j-log4j12 "1.6.6"]]
               :plugins [[lein-junit "1.1.5"]]}
              :provided
-             {:dependencies [[org.apache.hadoop/hadoop-core "1.2.1"]]}}
-  :classifiers {:javadoc {:java-source-paths ^:replace []
-                          :source-paths ^:replace []
-                          :resource-paths ^:replace []}
-                :sources {:java-source-paths ^:replace []
-                          :resource-paths ^:replace []}})
+             {:dependencies [[org.apache.hadoop/hadoop-core "1.2.1"]]}})


### PR DESCRIPTION
Here is some code to reproduce the issue

``` sh
$ cd dfs-datastores/dfs-datastores/

$ lein uberjar
Compiling 53 source files to /Users/bhiles/src/dfs-datastores/dfs-datastores/target/classes
warning: [options] bootstrap class path not set in conjunction with -source 1.6
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
1 warning
Created target/dfs-datastores-1.3.7-SNAPSHOT.jar
Created target/javadoc/dfs-datastores-1.3.7-SNAPSHOT-javadoc.jar
Created target/sources/dfs-datastores-1.3.7-SNAPSHOT-sources.jar
Created target/dfs-datastores-1.3.7-SNAPSHOT-standalone.jar

# No .class file for backtype is found :(
$ jar -tf target/dfs-datastores-1.3.7-SNAPSHOT-standalone.jar | grep back | grep .class
com/google/common/util/concurrent/FutureCallback.class

# After adding the change for this PR
› lein uberjar
Compiling 53 source files to /Users/bhiles/src/dfs-datastores/dfs-datastores/target/classes
warning: [options] bootstrap class path not set in conjunction with -source 1.6
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
1 warning
Created /Users/bhiles/src/dfs-datastores/dfs-datastores/target/dfs-datastores-1.3.7-SNAPSHOT.jar
Created /Users/bhiles/src/dfs-datastores/dfs-datastores/target/dfs-datastores-1.3.7-SNAPSHOT-standalone.jar

# Here you can find many backtype compiled classes
$ jar -tf target/dfs-datastores-1.3.7-SNAPSHOT-standalone.jar | grep back | grep .class | head
com/backtype/hadoop/AbstractFileCopyMapper.class
com/backtype/hadoop/BalancedDistcp$1.class
com/backtype/hadoop/BalancedDistcp$BalancedDistcpMapper.class
com/backtype/hadoop/BalancedDistcp.class
com/backtype/hadoop/Coercer$1.class
com/backtype/hadoop/Coercer$CoercerMapper.class
com/backtype/hadoop/Coercer.class
com/backtype/hadoop/Consolidator$1.class
com/backtype/hadoop/Consolidator$ConsolidatorArgs.class
com/backtype/hadoop/Consolidator$ConsolidatorInputFormat$1.class
```

I'm not quite sure how the `:classifier` logic works, I see it's included in this commit.  To try and validate nothing is broken on the pom side, I ran `lein pom` before and after the change, and came up with the same file.

Lastly, I've only modified the `dfs-datastores/dfs-datastores/project.clj`, so I'll need to modify the `dfs-datastores/dfs-datastores-cascading/project.clj` if this a solution.
