### PR TITLE
EMRFS workaround for creating $folder$ files

### DIFF
--- a/dfs-datastores/src/main/java/com/backtype/hadoop/AbstractFileCopyMapper.java
+++ b/dfs-datastores/src/main/java/com/backtype/hadoop/AbstractFileCopyMapper.java
@@ -44,14 +44,17 @@ public abstract class AbstractFileCopyMapper extends MapReduceBase implements Ma
                 return;
             }
         }
-
-        fsDest.mkdirs(tmpFile.getParent());
+        if (fsDest.getClass().getName().equals("com.amazon.ws.emr.hadoop.fs.EmrFileSystem")) {
+        	fsDest.mkdirs(tmpFile.getParent());
+        }
 
         copyFile(fsSource, sourceFile, fsDest, tmpFile, rprtr);
 
         setStatus(rprtr, "Renaming " + tmpFile.toString() + " to " + finalFile.toString());
 
-        fsDest.mkdirs(finalFile.getParent());
+        if (!fsDest.getClass().getName().equals("com.amazon.ws.emr.hadoop.fs.EmrFileSystem")) {
+        	fsDest.mkdirs(finalFile.getParent());
+        }
         if(!fsDest.rename(tmpFile, finalFile))
             throw new IOException("could not rename " + tmpFile.toString() + " to " + finalFile.toString());
 

--- a/dfs-datastores/src/main/java/com/backtype/hadoop/Consolidator.java
+++ b/dfs-datastores/src/main/java/com/backtype/hadoop/Consolidator.java
@@ -90,7 +90,6 @@ public class Consolidator {
         Utils.setObject(conf, ARGS, args);
 
         conf.setJobName("Consolidator: " + getDirsString(dirs));
-        LOG.debug("FileSystem {}",fs.getClass());
 
         conf.setInputFormat(ConsolidatorInputFormat.class);
         conf.setOutputFormat(NullOutputFormat.class);
@@ -158,9 +157,6 @@ public class Consolidator {
             for(int i=0; i<sourcesArr.get().length; i++) {
                 sources.add(new Path(((Text)sourcesArr.get()[i]).toString()));
             }
-            System.err.println("Filesystem class: "+fs.getClass());
-            System.out.println("Filesystem class: "+fs.getClass());
-            LOG.info("Filesystem class: "+fs.getClass());
             //must have failed after succeeding to create file but before task finished - this is valid
             //because path is selected with a UUID
             if(!fs.exists(finalFile)) {
@@ -215,9 +211,6 @@ public class Consolidator {
             args = (ConsolidatorArgs) Utils.getObject(conf, ARGS);
             try {
                 fs = Utils.getFS(args.fsUri, conf);
-                System.err.println("Filesystem class: "+fs.getClass());
-                System.out.println("Filesystem class: "+fs.getClass());
-                LOG.info("Filesystem class: "+fs.getClass());
             } catch(IOException e) {
                 throw new RuntimeException(e);
             }

--- a/dfs-datastores/src/main/java/com/backtype/hadoop/Consolidator.java
+++ b/dfs-datastores/src/main/java/com/backtype/hadoop/Consolidator.java
@@ -161,18 +161,18 @@ public class Consolidator {
             //because path is selected with a UUID
             if(!fs.exists(finalFile)) {
                 Path tmpFile = new Path("/tmp/consolidator/" + UUID.randomUUID().toString());
-                if (!fs.getClass().getName().equals("com.amazon.ws.emr.hadoop.fs.EmrFileSystem")) {
+//                if (!fs.getClass().getName().equals("com.amazon.ws.emr.hadoop.fs.EmrFileSystem")) {
                 	fs.mkdirs(tmpFile.getParent());
-                }
+//                }
 
                 String status = "Consolidating " + sources.size() + " files into " + tmpFile.toString();
                 LOG.info(status);
                 rprtr.setStatus(status);
 
                 RecordStreamFactory fact = args.streams;
-                if (!fs.getClass().getName().equals("com.amazon.ws.emr.hadoop.fs.EmrFileSystem")) {
+//                if (!fs.getClass().getName().equals("com.amazon.ws.emr.hadoop.fs.EmrFileSystem")) {
                 	fs.mkdirs(finalFile.getParent());
-                }
+//                }
 
                 RecordOutputStream os = fact.getOutputStream(fs, tmpFile);
                 for(Path i: sources) {

--- a/dfs-datastores/src/main/java/com/backtype/hadoop/datastores/VersionedStore.java
+++ b/dfs-datastores/src/main/java/com/backtype/hadoop/datastores/VersionedStore.java
@@ -245,7 +245,9 @@ public class VersionedStore {
             new File(path).mkdirs();
         else {
             try {
-                fs.mkdirs(new Path(path));
+            	if (!fs.getClass().getName().equals("com.amazon.ws.emr.hadoop.fs.EmrFileSystem")) {
+            		fs.mkdirs(new Path(path));
+            	}
             } catch (AccessControlException e) {
                 throw new RuntimeException("Root directory doesn't exist, and user doesn't have the permissions " +
                                            "to create" + path + ".", e);

--- a/dfs-datastores/src/main/java/com/backtype/hadoop/pail/AbstractLocalPail.java
+++ b/dfs-datastores/src/main/java/com/backtype/hadoop/pail/AbstractLocalPail.java
@@ -36,6 +36,9 @@ public abstract class AbstractLocalPail extends AbstractPail {
 
     @Override
     protected boolean mkdirs(Path path) throws IOException {
+    	if (_lfs.getClass().getName().equals("com.amazon.ws.emr.hadoop.fs.EmrFileSystem")) {
+    		return true;
+    	}
         return _lfs.mkdirs(path);
     }
 

--- a/dfs-datastores/src/main/java/com/backtype/hadoop/pail/Pail.java
+++ b/dfs-datastores/src/main/java/com/backtype/hadoop/pail/Pail.java
@@ -177,7 +177,9 @@ public class Pail<T> extends AbstractPail implements Iterable<T>{
                 }
             }
         }
-        fs.mkdirs(pathp);
+        if (!fs.getClass().getName().equals("com.amazon.ws.emr.hadoop.fs.EmrFileSystem")) {
+        	fs.mkdirs(pathp);
+        }
         if(existing==null) {
             if(spec==null) spec = PailFormatFactory.getDefaultCopy();
             if(spec.getName()==null) spec = PailFormatFactory.getDefaultCopy().setStructure(spec.getStructure());
@@ -441,7 +443,9 @@ public class Pail<T> extends AbstractPail implements Iterable<T>{
 
         for(String name: p.getUserFileNames()) {
             String parent = new Path(name).getParent().toString();
-            _fs.mkdirs(new Path(getInstanceRoot() + "/" + parent));
+            if (!_fs.getClass().getName().equals("com.amazon.ws.emr.hadoop.fs.EmrFileSystem")) {
+            	_fs.mkdirs(new Path(getInstanceRoot() + "/" + parent));
+            }
             Path storedPath = p.toStoredPath(name);
             Path targetPath = toStoredPath(name);
             if(_fs.exists(targetPath) || args.renameMode == RenameMode.ALWAYS_RENAME) {
@@ -565,6 +569,9 @@ public class Pail<T> extends AbstractPail implements Iterable<T>{
 
     @Override
     protected boolean mkdirs(Path path) throws IOException {
+    	if (_fs.getClass().getName().equals("com.amazon.ws.emr.hadoop.fs.EmrFileSystem")) {
+    		return true;
+    	}
         return _fs.mkdirs(path);
     }
 

--- a/dfs-datastores/src/main/java/com/backtype/support/TestUtils.java
+++ b/dfs-datastores/src/main/java/com/backtype/support/TestUtils.java
@@ -37,7 +37,9 @@ public class TestUtils {
     }
 
     public static String getTmpPath(FileSystem fs, String name) throws IOException {
-        fs.mkdirs(new Path(TMP_ROOT));
+    	if (!fs.getClass().getName().equals("com.amazon.ws.emr.hadoop.fs.EmrFileSystem")) {
+    		fs.mkdirs(new Path(TMP_ROOT));
+    	}
         String full = TMP_ROOT + "/" + name;
         if (fs.exists(new Path(full))) {
             fs.delete(new Path(full), true);


### PR DESCRIPTION
Unfortunately the proprietary Amazon EMRFS is using a modified version of the NativeS3Filesystem. This file system creates _$folder$ files on S3 which can cause the map reduce job to slow down due to reading all the files.
This pull request is working around this issue and is not creating any directories when using com.amazon.ws.emr.hadoop.fs.EmrFileSystem (which is the default for s3:// on EMR).
